### PR TITLE
ID-4293: https i redirect urls i systest og profiler for test/prod

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,27 @@
+management:
+  endpoint:
+    health:
+      show-details: always
+      show-components: always
+spring:
+  application:
+    environment: test
+  main:
+    log-startup-info: true
+  data:
+    redis:
+      password: ${REDIS_PASSWORD}
+      port: 6379
+      host: eidas-redis-sentinel-master
+eidas:
+  cache:
+    response-secret: ${LIGHT_TOKEN_PROXYSERVICE_RESPONSE_SECRET}
+    request-secret: ${LIGHT_TOKEN_PROXYSERVICE_REQUEST_SECRET}
+  eu-proxy:
+    redirect-uri: https://proxy.eidasnode.no/SpecificProxyServiceResponse
+  oidc-integration:
+    issuer: https://idporten.no
+    client-id: eidas-proxy-client-prod
+    client-auth-method: client_secret_basic
+    client-secret: ${EIDAS_CLIENT_SECRET}
+    redirect-uri: https://idporten-proxy.eidasnode.no/idpcallback

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,13 +1,12 @@
 management:
   endpoint:
     health:
-      show-details: always
+      show-details: never
       show-components: always
 spring:
   application:
     environment: test
-  main:
-    log-startup-info: true
+
   data:
     redis:
       password: ${REDIS_PASSWORD}

--- a/src/main/resources/application-systest.yaml
+++ b/src/main/resources/application-systest.yaml
@@ -24,4 +24,4 @@ eidas:
     client-id: eidas-proxy-client-dev
     client-auth-method: client_secret_basic
     client-secret: ${EIDAS_CLIENT_SECRET}
-    redirect-uri: http://idporten-proxy.eidasnode.dev/idpcallback
+    redirect-uri: https://idporten-proxy.eidasnode.dev/idpcallback

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,13 +1,12 @@
 management:
   endpoint:
     health:
-      show-details: always
+      show-details: never
       show-components: always
 spring:
   application:
     environment: test
-  main:
-    log-startup-info: true
+
   data:
     redis:
       password: ${REDIS_PASSWORD}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,0 +1,27 @@
+management:
+  endpoint:
+    health:
+      show-details: always
+      show-components: always
+spring:
+  application:
+    environment: test
+  main:
+    log-startup-info: true
+  data:
+    redis:
+      password: ${REDIS_PASSWORD}
+      port: 6379
+      host: eidas-redis-sentinel-master
+eidas:
+  cache:
+    response-secret: ${LIGHT_TOKEN_PROXYSERVICE_RESPONSE_SECRET}
+    request-secret: ${LIGHT_TOKEN_PROXYSERVICE_REQUEST_SECRET}
+  eu-proxy:
+    redirect-uri: https://proxy.test.eidasnode.no/SpecificProxyServiceResponse
+  oidc-integration:
+    issuer: https://test.idporten.no
+    client-id: eidas-proxy-client-test
+    client-auth-method: client_secret_basic
+    client-secret: ${EIDAS_CLIENT_SECRET}
+    redirect-uri: https://idporten-proxy.test.eidasnode.no/idpcallback

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,7 +32,7 @@ management:
           include: redis
 spring:
   application:
-    name: eidas-proxy
+    name: idporten-proxy
     environment: prod
   main:
     lazy-initialization: false


### PR DESCRIPTION
Endra application-name til idporten-proxy.
Justert litt på test/prod profiler: ingen logging på start up + ikkje vise detaljer på helseendepunkt.