### PR TITLE
ID-4489: Fjerne null values i auditlogging for LightRequest/Response.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <open.telemetry.version>1.39.0</open.telemetry.version>
         <logstash.logback.version>7.4</logstash.logback.version>
-        <idporten-audit.version>1.2.4</idporten-audit.version>
         <idporten-access-log.version>2.3.4</idporten-access-log.version>
         <idporten-metric-constants.version>1.1.0</idporten-metric-constants.version>
         <idporten-actuator-starter.version>1.2.0</idporten-actuator-starter.version>

--- a/src/main/java/no/idporten/eidas/proxy/lightprotocol/messages/LightRequest.java
+++ b/src/main/java/no/idporten/eidas/proxy/lightprotocol/messages/LightRequest.java
@@ -11,8 +11,10 @@ import no.idporten.logging.audit.AuditEntryProvider;
 
 import javax.annotation.Nonnull;
 import java.io.Serial;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @XmlRootElement(namespace = "http://cef.eidas.eu/LightRequest")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -83,16 +85,21 @@ public class LightRequest implements ILightRequest, AuditEntryProvider {
     public AuditEntry getAuditEntry() {
         return AuditEntry.builder()
                 .auditId(AuditIdPattern.EIDAS_LIGHT_REQUEST.auditIdentifier())
-                .attribute("light_request", Map.of(
-                        "id", id,
-                        "relay_state", relayState,
-                        "citizen_country_code", citizenCountryCode,
-                        "level_of_assurance_requested", levelOfAssurance,
-                        "sp_country_code", spCountryCode,
-                        "requested_attributes", requestedAttributes
-                ))
+                .attribute("light_request", createMapForAuditLogging())
                 .logNullAttributes(false)
                 .build();
+    }
+
+    private Map<String, Object> createMapForAuditLogging() {
+        HashMap<String, Object> all = new HashMap<>();
+        all.put("id", id);
+        all.put("relay_state", relayState);
+        all.put("citizen_country_code", citizenCountryCode);
+        all.put("level_of_assurance", levelOfAssurance);
+        all.put("sp_country_code", spCountryCode);
+        all.put("attributes", requestedAttributes);
+        all.values().removeIf(Objects::isNull);
+        return Map.copyOf(all); // Immutable map throws NPE if values (or keys) is null
     }
 }
 

--- a/src/main/java/no/idporten/eidas/proxy/lightprotocol/messages/LightResponse.java
+++ b/src/main/java/no/idporten/eidas/proxy/lightprotocol/messages/LightResponse.java
@@ -8,12 +8,15 @@ import lombok.*;
 import no.idporten.eidas.proxy.logging.AuditIdPattern;
 import no.idporten.logging.audit.AuditEntry;
 import no.idporten.logging.audit.AuditEntryProvider;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serial;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @XmlRootElement(name = "lightResponse", namespace = "http://cef.eidas.eu/LightResponse")
 @XmlType
@@ -99,18 +102,23 @@ public class LightResponse implements ILightResponse, AuditEntryProvider {
     public AuditEntry getAuditEntry() {
         return AuditEntry.builder()
                 .auditId(AuditIdPattern.EIDAS_LIGHT_RESPONSE.auditIdentifier())
-                .attribute("light_response", Map.of(
-                        "id", id,
-                        "issuer", issuer,
-                        "status", status,
-                        "in_response_to_id", inResponseToId,
-                        "relay_state", relayState,
-                        "country_code", citizenCountryCode,
-                        "level_of_assurance_returned", levelOfAssurance,
-                        "sub", subject,
-                        "attributes", attributes
-                ))
+                .attribute("light_response", createMapForAuditLogging())
                 .build();
+    }
+
+    private Map<String, Object> createMapForAuditLogging() {
+        HashMap<String, Object> all = new HashMap<>();
+        all.put("id", id);
+        all.put("issuer", issuer);
+        all.put("status", status);
+        all.put("in_response_to_id", inResponseToId);
+        all.put("relay_state", relayState);
+        all.put("citizen_country_code", citizenCountryCode);
+        all.put("level_of_assurance", levelOfAssurance);
+        all.put("sub", subject);
+        all.put("attributes", attributes);
+        all.values().removeIf(Objects::isNull);
+        return Map.copyOf(all); // Immutable map throws NPE if values (or keys) is null
     }
 
 }

--- a/src/main/resources/application-local-docker.yaml
+++ b/src/main/resources/application-local-docker.yaml
@@ -30,4 +30,4 @@ eidas:
     client-id: eidas-proxy-client-dev
     client-auth-method: client_secret_basic
     client-secret: 3aee797c-3fd4-46f2-8faf-ebff1a131055
-    redirect-uri: http://eidas-proxy:8077/idpcallback
+    redirect-uri: http://idporten-proxy:8077/idpcallback

--- a/src/test/java/no/idporten/eidas/proxy/lightprotocol/LightRequestTest.java
+++ b/src/test/java/no/idporten/eidas/proxy/lightprotocol/LightRequestTest.java
@@ -1,0 +1,51 @@
+package no.idporten.eidas.proxy.lightprotocol;
+
+import no.idporten.eidas.proxy.lightprotocol.messages.*;
+import no.idporten.eidas.proxy.logging.AuditIdPattern;
+import no.idporten.logging.audit.AuditEntry;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class LightRequestTest {
+
+    @Test
+    public void getAuditEntryWhenEmtpyThenDoesNotFailAndLoggesEmptyRequest() {
+        AuditEntry auditEntry = new LightRequest().getAuditEntry();
+        assertNotNull(auditEntry);
+        assertEquals(AuditIdPattern.EIDAS_LIGHT_REQUEST.auditIdentifier().auditId(), auditEntry.getAuditId().auditId());
+        assertEquals(1, auditEntry.getAttributes().size());
+        assertNotNull(auditEntry.getAttribute("light_request"));
+        Map lightRequest = (Map) auditEntry.getAttribute("light_request");
+        assertEquals(0, lightRequest.size());
+
+    }
+
+    @Test
+    public void getAuditEntryWhenRequestHasAll6AttributesThenLoggesAllAttributes() {
+        AuditEntry auditEntry = createLightRequest().getAuditEntry();
+        assertNotNull(auditEntry);
+        assertEquals(AuditIdPattern.EIDAS_LIGHT_REQUEST.auditIdentifier().auditId(), auditEntry.getAuditId().auditId());
+        assertEquals(1, auditEntry.getAttributes().size());
+        assertNotNull(auditEntry.getAttribute("light_request"));
+        Map lightRequest = (Map) auditEntry.getAttribute("light_request");
+        assertEquals(6, lightRequest.size());
+    }
+
+    private static LightRequest createLightRequest() {
+        return LightRequest.builder()
+                .id("id")
+                .requestedAttributes(List.of(new RequestedAttribute()))
+                .relayState("state")
+                .citizenCountryCode("CA")
+                .spCountryCode("CB")
+                .levelOfAssurance((LevelOfAssurance) LevelOfAssurance.fromString(LevelOfAssurance.EIDAS_LOA_HIGH))
+                .build();
+    }
+
+
+}

--- a/src/test/java/no/idporten/eidas/proxy/lightprotocol/LightResponseTest.java
+++ b/src/test/java/no/idporten/eidas/proxy/lightprotocol/LightResponseTest.java
@@ -1,0 +1,54 @@
+package no.idporten.eidas.proxy.lightprotocol;
+
+import no.idporten.eidas.proxy.lightprotocol.messages.Attribute;
+import no.idporten.eidas.proxy.lightprotocol.messages.LightResponse;
+import no.idporten.eidas.proxy.lightprotocol.messages.Status;
+import no.idporten.eidas.proxy.logging.AuditIdPattern;
+import no.idporten.logging.audit.AuditEntry;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LightResponseTest {
+
+    @Test
+    public void getAuditEntryWhenEmtpyThenDoesNotFailAndLoggesEmptyResponse() {
+        AuditEntry auditEntry = new LightResponse().getAuditEntry();
+        assertNotNull(auditEntry);
+        assertEquals(AuditIdPattern.EIDAS_LIGHT_RESPONSE.auditIdentifier().auditId(), auditEntry.getAuditId().auditId());
+        assertEquals(1, auditEntry.getAttributes().size());
+        assertNotNull(auditEntry.getAttribute("light_response"));
+        Map lightResponse = (Map) auditEntry.getAttribute("light_response");
+        assertEquals(0, lightResponse.size());
+
+    }
+
+    @Test
+    public void getAuditEntryWhenResponseHasAll9AttributesThenLoggesAllAttributes() {
+        AuditEntry auditEntry = createLightResponse().getAuditEntry();
+        assertNotNull(auditEntry);
+        assertEquals(AuditIdPattern.EIDAS_LIGHT_RESPONSE.auditIdentifier().auditId(), auditEntry.getAuditId().auditId());
+        assertEquals(1, auditEntry.getAttributes().size());
+        assertNotNull(auditEntry.getAttribute("light_response"));
+        Map lightResponse = (Map) auditEntry.getAttribute("light_response");
+        assertEquals(9, lightResponse.size());
+    }
+
+    private static LightResponse createLightResponse() {
+        return LightResponse.builder()
+                .subject("sub")
+                .inResponseToId("responseTo")
+                .id("id")
+                .attribute(new Attribute())
+                .relayState("state")
+                .citizenCountryCode("CA")
+                .issuer("http://dd")
+                .levelOfAssurance("A")
+                .status(Status.builder().statusCode("ok").build())
+                .build();
+    }
+
+
+}


### PR DESCRIPTION
Og korrekt port for docker lokal utvikling.