### PR TITLE
ID-6225: Add `profile` scope to `idporten` and `ansattporten` configurations

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,6 +75,7 @@ eidas:
     idporten:
       scopes:
         - openid
+        - profile
         - eidas:mds
       connect-timeout-millis: 500
       read-timeout-millis: 500
@@ -83,6 +84,7 @@ eidas:
     ansattporten:
       scopes:
         - openid
+        - profile
         - eidas:mds
       connect-timeout-millis: 500
       read-timeout-millis: 500


### PR DESCRIPTION
SAK:
ID-6225

Sjekklister:  
Eigar:

- [x] Vurdert Manual deploy
- [x] Vurdert "internal"
- [x] Avhengigheter til andre saker avklart
- [x] Evt nye avhengigheter til andre komponenter dokumentert i catalog-info
- [x] Har kjørt opp lokalt med docker-compose
- [x] Oppdatering/oppretting av regresjonstester er avklart/utført
- [x] Har oppdatert dependabots
- [x] Har trimmet .trivyignore

Kodeles:

- [x] Lesbar kode, nødvendige kommentarer
- [x] Sak er godt nok forklart/dokumentert
- [x] Løyser saka
- [x] Risikovurdering ok
- [x] Nødvendige unit-tester er på plass
- [x] Nødvendige regresjonstester er oppdatert/oppretta/planlagt
- [x] Har oppdatert readme (evt digdir docs om nødvendig)